### PR TITLE
moving map css file to application.scss

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link helping.png
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,4 @@
 @import "components/index";
 @import "pages/index";
 @import "pages/show";
+@import "mapbox-gl/dist/mapbox-gl.css";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_pack_tag 'map' %>
+    <%# <%= stylesheet_pack_tag 'map' %>
     <%#  Google Fonts 'Inter' %>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -7,6 +7,7 @@ default: &default
   public_output_path: packs
   cache_path: tmp/cache/webpacker
   webpack_compile_output: true
+  compile: true
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']


### PR DESCRIPTION
Moved map.css pack_tag to application.scss because it was giving an error on heroku